### PR TITLE
Add evc-team-relay-mcp - Obsidian vault MCP server

### DIFF
--- a/servers/@entire-vc/evc-team-relay-mcp.json
+++ b/servers/@entire-vc/evc-team-relay-mcp.json
@@ -1,0 +1,38 @@
+{
+    "id": "evc-team-relay-mcp",
+    "name": "EVC Team Relay MCP",
+    "title": "EVC Team Relay",
+    "description": "MCP server that gives AI agents read/write access to your Obsidian vault via EVC Team Relay. Supports real-time collaborative editing and CRDT-based sync.",
+    "tags": ["obsidian", "knowledge-management", "notes", "pkm", "collaboration", "vault"],
+    "creator": "entire-vc",
+    "publishDate": "2026-02-01T00:00:00Z",
+    "rating": 5,
+    "type": "stdio",
+    "commandInfo": {
+        "command": "uvx",
+        "args": ["evc-team-relay-mcp"],
+        "env": {
+            "RELAY_CP_URL": "<YOUR_RELAY_URL>",
+            "RELAY_EMAIL": "<YOUR_EMAIL>",
+            "RELAY_PASSWORD": "<YOUR_PASSWORD>"
+        }
+    },
+    "defVersion": "1",
+    "parameters": {
+        "RELAY_CP_URL": {
+            "type": "string",
+            "required": true,
+            "description": "EVC Team Relay control plane URL"
+        },
+        "RELAY_EMAIL": {
+            "type": "string",
+            "required": true,
+            "description": "Your EVC Team Relay account email"
+        },
+        "RELAY_PASSWORD": {
+            "type": "string",
+            "required": true,
+            "description": "Your EVC Team Relay account password"
+        }
+    }
+}


### PR DESCRIPTION
Add evc-team-relay-mcp to the registry.

EVC Team Relay MCP is an MCP server that lets AI agents read and write to your Obsidian vault via EVC Team Relay. It uses CRDT-based sync for real-time collaborative editing.

- GitHub: https://github.com/entire-vc/evc-team-relay-mcp
- PyPI: https://pypi.org/project/evc-team-relay-mcp/

Homepage: https://entire.vc/team-relay/ai/
